### PR TITLE
Fix WebView overflow and disable user zooming

### DIFF
--- a/android/app/src/main/assets/epub.html
+++ b/android/app/src/main/assets/epub.html
@@ -2,12 +2,14 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.5/jszip.min.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/epubjs/dist/epub.min.js"></script>
 		<style>
-			#reader {
-				margin: 0px;
+			body {
+				margin: 0;
+			}
+			#reader {				
 				height: 100vh;
 				width: 100vw;
 				overflow: hidden !important;


### PR DESCRIPTION
On my smartphone, WebView was overflowing. This was happening because by default body has borders on it, and since the div container is taking 100vh and 100vw, this was causing WebView to overflow.

I've also disabled the zooming/scaling  so that the WebView zoom scale is fixed.