### PR TITLE
Android crash when speaking non-bcp language

### DIFF
--- a/src/components/DictionaryModal.js
+++ b/src/components/DictionaryModal.js
@@ -27,14 +27,14 @@ function DictionaryModal(props) {
 	}, [props.sLang, props.tLang]);
 
 	function speakSrc() {
-		if (langIndex.src > -1) {
+		if (langIndex.src > -1 && languages[langIndex.src].bcp) {
 			Tts.setDefaultLanguage(languages[langIndex.src].bcp);
 			Tts.speak(props.selected);
 		} else showToast('Pronunciation not available for this language');
 	}
 
 	function speakTrg() {
-		if (langIndex.trg > -1) {
+		if (langIndex.trg > -1 && languages[langIndex.trg].bcp) {
 			Tts.setDefaultLanguage(languages[langIndex.trg].bcp);
 			Tts.speak(translation);
 		} else showToast('Pronunciation not available for this language');


### PR DESCRIPTION
On Android, using the "speak" button on a language with no [bcp values set](https://github.com/farshed/duofolio/blob/master/src/constants/index.js#L10) causes the app to crash.

I do not have a test environment setup for android apps, but I believe this small change should correct this.