### PR TITLE
mock rest api added

### DIFF
--- a/mock-api/api/translate/GET.json
+++ b/mock-api/api/translate/GET.json
@@ -1,0 +1,1 @@
+[[["Lorem ipsum"]]]

--- a/mock-api/index.js
+++ b/mock-api/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const apiMocker = require('connect-api-mocker');
+
+const app = express();
+
+app.use('/api', apiMocker('mock-api/api'));
+
+app.listen(8080);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"ios": "react-native run-ios",
 		"start": "react-native start",
 		"test": "jest",
-		"lint": "eslint ."
+		"lint": "eslint .",
+		"mock-api": "node mock-api/index.js"
 	},
 	"dependencies": {
 		"@react-native-community/masked-view": "^0.1.10",
@@ -40,7 +41,9 @@
 		"@babel/runtime": "^7.6.2",
 		"@react-native-community/eslint-config": "^0.0.5",
 		"babel-jest": "^24.9.0",
+		"connect-api-mocker": "^1.9.0",
 		"eslint": "^6.5.1",
+		"express": "^4.17.1",
 		"jest": "^24.9.0",
 		"metro-react-native-babel-preset": "^0.58.0",
 		"react-test-renderer": "16.11.0"


### PR DESCRIPTION
i had issue with setup dev env. i read issue #10  then i decided to implement mock rest api to run on local easily.

i added connect-api-mocker. it makes rest api with json and js file.  when execute  npm run mock-api , it hosts a rest api at 'http://localhost:8080/api/translate' and return  '[[["Lorem ipsum"]]]' .  this is a mock value for translateApiUrl function. so you can use this url on constant/private  then the developers works on local easily.